### PR TITLE
fix: setup secrets script and documentation - closes #2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Copycat AI - Variables d'environnement
+#
+# Ce fichier est un exemple. Ne le modifiez pas directement.
+# Copiez-le en .dev.vars pour le développement local.
+#
+# Les secrets sensibles (STRIPE_SECRET_KEY, JWT_SECRET, etc.)
+# doivent être configurés avec wrangler secret put.
+# Utilisez le script ./scripts/setup-secrets.sh pour faciliter la configuration.
+
+# ═══════════════════════════════════════════════════════════════
+# SECRETS (configurer avec wrangler secret put ou setup-secrets.sh)
+# ═══════════════════════════════════════════════════════════════
+# Ces variables ne doivent JAMAIS être commitées !
+
+# Stripe - https://dashboard.stripe.com/apikeys
+# STRIPE_SECRET_KEY=sk_test_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+
+# Authentification JWT
+# JWT_SECRET=votre-secret-jwt-tres-long-et-aleatoire
+
+# AI API Keys
+# KIMI_API_KEY=kimi-...
+# OPENAI_API_KEY=sk-...
+
+# ═══════════════════════════════════════════════════════════════
+# VARIABLES PUBLIQUES (peuvent être dans wrangler.toml)
+# ═══════════════════════════════════════════════════════════════
+
+# Environnement
+ENVIRONMENT=development
+
+# Stripe
+STRIPE_PUBLISHABLE_KEY=pk_test_...
+
+# Analytics - https://eu.posthog.com
+POSTHOG_KEY=ph_
+POSTHOG_HOST=https://eu.i.posthog.com
+
+# Monitoring - https://betterstack.com
+BETTERSTACK_TOKEN=votre-token
+
+# URL de l'application
+APP_URL=http://localhost:8787

--- a/AGENT_WORK.md
+++ b/AGENT_WORK.md
@@ -1,0 +1,58 @@
+# AGENT_WORK.md - Journal de travail
+
+## Issue #2 : Configurer les secrets Cloudflare
+
+### Problème
+La configuration des secrets pour le développement local et la production était manuelle et source d'erreurs. L'issue demandait de documenter les commandes `wrangler secret put`.
+
+### Solution implémentée
+
+#### 1. Script automatisé (`scripts/setup-secrets.sh`)
+- Script bash interactif pour configurer les 4 secrets requis
+- Supporte deux modes : `--local` (développement) et `--production`
+- Validation de la présence de wrangler CLI
+- Interface utilisateur colorée avec des étapes claires
+- Affichage des prochaines étapes après configuration
+
+#### 2. Fichier template (`.env.example`)
+- Documentation complète des variables d'environnement
+- Distinction claire entre secrets (sensibles) et variables publiques
+- Instructions sur où trouver chaque valeur
+
+#### 3. Mise à jour du `package.json`
+- Nouveaux scripts npm :
+  - `setup:secrets` : Setup local interactif
+  - `setup:secrets:prod` : Setup production interactif
+  - `db:schema` : Appliquer le schéma en local (correction du script existant)
+  - `db:schema:prod` : Appliquer le schéma en production
+
+#### 4. Documentation README.md
+- Section "Setup Local" complètement réécrite avec 5 étapes claires
+- Section "Déploiement Production" détaillée
+- Tableau des secrets GitHub Actions avec descriptions
+
+### Tests effectués
+- ✅ `npm run typecheck` - Pas d'erreurs TypeScript
+- ✅ Syntaxe du script bash vérifiée
+
+### Fichiers modifiés/créés
+```
+NEW: scripts/setup-secrets.sh
+NEW: .env.example
+MOD: package.json (nouveaux scripts)
+MOD: README.md (documentation setup)
+```
+
+### Commandes pour tester
+```bash
+# Vérifier que le script est exécutable
+./scripts/setup-secrets.sh --help
+
+# Setup local interactif
+npm run setup:secrets
+
+# Setup production
+npm run setup:secrets:prod
+```
+
+---

--- a/README.md
+++ b/README.md
@@ -55,38 +55,113 @@ src/
 
 ## 🛠️ Setup Local
 
-```bash
-# Installation
-npm install
+### 1. Installation
 
-# Configurer les secrets locaux
+```bash
+npm install
+```
+
+### 2. Configuration des Secrets
+
+**Option A : Script automatisé (recommandé)**
+
+```bash
+# Configuration interactive de tous les secrets
+./scripts/setup-secrets.sh --local
+```
+
+**Option B : Manuellement**
+
+```bash
+# Configurer les secrets un par un
+wrangler secret put STRIPE_SECRET_KEY --local
+wrangler secret put STRIPE_WEBHOOK_SECRET --local
+wrangler secret put JWT_SECRET --local
+wrangler secret put KIMI_API_KEY --local
+```
+
+Les secrets requis sont :
+- `STRIPE_SECRET_KEY` - Clé secrète Stripe (sk_...)
+- `STRIPE_WEBHOOK_SECRET` - Secret webhook Stripe (whsec_...)
+- `JWT_SECRET` - Secret pour signer les JWT (générez une chaîne aléatoire)
+- `KIMI_API_KEY` - Clé API pour l'IA (ou `OPENAI_API_KEY`)
+
+### 3. Base de données D1
+
+```bash
+# Créer la base de données
+npm run db:create
+# Copier l'ID affiché dans wrangler.toml (champ database_id)
+
+# Appliquer le schéma
+npm run db:schema
+```
+
+### 4. Variables d'environnement
+
+```bash
+# Copier le fichier d'exemple
+cp .env.example .dev.vars
+# Éditer .dev.vars avec vos valeurs
+```
+
+### 5. Lancer le serveur
+
+```bash
+npm run dev
+# Ouvrir http://localhost:8787
+```
+
+## 🚀 Déploiement Production
+
+### 1. Secrets Cloudflare (Production)
+
+```bash
+# Configurer les secrets pour la production
+npm run setup:secrets:prod
+```
+
+Ou manuellement :
+```bash
 wrangler secret put STRIPE_SECRET_KEY
 wrangler secret put STRIPE_WEBHOOK_SECRET
 wrangler secret put JWT_SECRET
 wrangler secret put KIMI_API_KEY
+```
 
-# Créer la base de données D1
+### 2. Variables dans wrangler.toml
+
+Éditer `wrangler.toml` et remplacer :
+- `STRIPE_PUBLISHABLE_KEY` - Clé publique Stripe (pk_live_...)
+- `POSTHOG_KEY` - Clé PostHog
+- `BETTERSTACK_TOKEN` - Token BetterStack
+- `APP_URL` - URL de votre application
+- `database_id` - ID de la base D1 créée
+
+### 3. Base de données D1 (Production)
+
+```bash
+# Créer la base de données de production
 wrangler d1 create copycat-ai-db
 # Copier l'ID dans wrangler.toml
 
 # Appliquer le schéma
-wrangler d1 execute copycat-ai-db --file=./src/db/schema.sql
-
-# Démarrer le dev server
-npm run dev
+npm run db:schema:prod
 ```
 
-## 🚀 Déploiement
+### 4. Déploiement Automatique (GitHub Actions)
 
-Le déploiement est automatique via GitHub Actions sur chaque push sur `main`.
+Le déploiement est automatique sur chaque push sur `main`.
 
-### Secrets GitHub à configurer:
-- `CLOUDFLARE_API_TOKEN`
-- `CLOUDFLARE_ACCOUNT_ID`
-- `STRIPE_SECRET_KEY`
-- `STRIPE_WEBHOOK_SECRET`
-- `JWT_SECRET`
-- `KIMI_API_KEY`
+**Secrets GitHub requis** (Settings > Secrets and variables > Actions):
+| Secret | Description | Où le trouver |
+|--------|-------------|---------------|
+| `CLOUDFLARE_API_TOKEN` | Token API Cloudflare | [Cloudflare Tokens](https://dash.cloudflare.com/profile/api-tokens) |
+| `CLOUDFLARE_ACCOUNT_ID` | ID du compte Cloudflare | Dashboard > droite, Account ID |
+| `STRIPE_SECRET_KEY` | Clé secrète Stripe | [Stripe Dashboard](https://dashboard.stripe.com/apikeys) |
+| `STRIPE_WEBHOOK_SECRET` | Secret webhook | Stripe > Webhooks > Signing secret |
+| `JWT_SECRET` | Secret JWT | Générez: `openssl rand -base64 32` |
+| `KIMI_API_KEY` | Clé API Kimi | Dashboard Kimi |
 
 ## 📊 Monitoring
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "build": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js --platform=neutral",
     "db:create": "wrangler d1 create copycat-ai-db",
     "db:migrate": "wrangler d1 migrations apply copycat-ai-db",
-    "db:schema": "wrangler d1 execute copycat-ai-db --file=./src/db/schema.sql",
+    "db:schema": "wrangler d1 execute copycat-ai-db --file=./src/db/schema.sql --local",
+    "db:schema:prod": "wrangler d1 execute copycat-ai-db --file=./src/db/schema.sql",
+    "setup:secrets": "./scripts/setup-secrets.sh --local",
+    "setup:secrets:prod": "./scripts/setup-secrets.sh --production",
     "typecheck": "tsc --noEmit",
     "test": "vitest"
   },

--- a/scripts/setup-secrets.sh
+++ b/scripts/setup-secrets.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# Setup script for Copycat AI secrets
+# Usage: ./scripts/setup-secrets.sh [--local|--production]
+#
+
+set -e
+
+ENV="${1:---local}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo ""
+    echo -e "${BLUE}══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  Copycat AI - Configuration des Secrets${NC}"
+    echo -e "${BLUE}══════════════════════════════════════════════════════════════${NC}"
+    echo ""
+}
+
+print_step() {
+    echo -e "${YELLOW}→${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}✗${NC} $1"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+check_wrangler() {
+    if ! command -v wrangler &> /dev/null; then
+        print_error "wrangler CLI n'est pas installé"
+        echo ""
+        echo "Installez-le avec :"
+        echo "  npm install -g wrangler"
+        exit 1
+    fi
+    print_success "wrangler CLI est installé"
+}
+
+get_secret() {
+    local name=$1
+    local description=$2
+    local example=$3
+    
+    echo ""
+    print_step "Configuration de ${YELLOW}${name}${NC}"
+    print_info "${description}"
+    if [ -n "$example" ]; then
+        print_info "Exemple: ${example}"
+    fi
+    echo ""
+    
+    if [ "$ENV" == "--production" ]; then
+        wrangler secret put "$name"
+    else
+        wrangler secret put "$name" --local
+    fi
+    
+    print_success "${name} configuré"
+}
+
+verify_secrets() {
+    echo ""
+    print_step "Vérification des secrets configurés..."
+    
+    if [ "$ENV" == "--production" ]; then
+        wrangler secret list
+    else
+        # Pour local, on vérifie juste le fichier .dev.vars
+        if [ -f "$SCRIPT_DIR/../.dev.vars" ]; then
+            print_success "Fichier .dev.vars trouvé"
+            echo ""
+            print_info "Secrets locaux configurés :"
+            grep -E "^[A-Z_]+=" "$SCRIPT_DIR/../.dev.vars" | cut -d'=' -f1 | while read -r secret; do
+                echo "  • $secret"
+            done
+        fi
+    fi
+}
+
+show_next_steps() {
+    echo ""
+    echo -e "${GREEN}══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${GREEN}  Configuration terminée !${NC}"
+    echo -e "${GREEN}══════════════════════════════════════════════════════════════${NC}"
+    echo ""
+    echo "Prochaines étapes :"
+    echo ""
+    
+    if [ "$ENV" == "--local" ]; then
+        echo "  1. Créer la base de données D1 :"
+        echo -e "     ${YELLOW}npm run db:create${NC}"
+        echo ""
+        echo "  2. Appliquer le schéma :"
+        echo -e "     ${YELLOW}wrangler d1 execute copycat-ai-db --file=./src/db/schema.sql --local${NC}"
+        echo ""
+        echo "  3. Lancer le serveur de développement :"
+        echo -e "     ${YELLOW}npm run dev${NC}"
+        echo ""
+        echo "  4. Ouvrir http://localhost:8787"
+    else
+        echo "  1. Configurer les autres variables dans wrangler.toml :"
+        echo -e "     ${YELLOW}- STRIPE_PUBLISHABLE_KEY${NC}"
+        echo -e "     ${YELLOW}- POSTHOG_KEY${NC}"
+        echo -e "     ${YELLOW}- BETTERSTACK_TOKEN${NC}"
+        echo ""
+        echo "  2. Déployer :"
+        echo -e "     ${YELLOW}npm run deploy${NC}"
+    fi
+    echo ""
+}
+
+main() {
+    print_header
+    
+    # Check arguments
+    if [ "$ENV" != "--local" ] && [ "$ENV" != "--production" ]; then
+        echo "Usage: ./scripts/setup-secrets.sh [--local|--production]"
+        echo ""
+        echo "Options:"
+        echo "  --local       Configurer pour le développement local (défaut)"
+        echo "  --production  Configurer pour la production"
+        exit 1
+    fi
+    
+    if [ "$ENV" == "--local" ]; then
+        print_info "Mode: Développement local"
+    else
+        print_info "Mode: Production"
+    fi
+    
+    check_wrangler
+    
+    # Configuration des secrets
+    echo ""
+    echo -e "${YELLOW}Configuration des 4 secrets requis :${NC}"
+    
+    get_secret "STRIPE_SECRET_KEY" \
+        "Clé secrète Stripe (commence par sk_...)" \
+        "sk_test_xxx ou sk_live_xxx"
+    
+    get_secret "STRIPE_WEBHOOK_SECRET" \
+        "Secret du webhook Stripe (pour recevoir les événements)" \
+        "whsec_xxx"
+    
+    get_secret "JWT_SECRET" \
+        "Secret pour signer les tokens JWT (générez une chaîne aléatoire)" \
+        "$(openssl rand -base64 32 2>/dev/null || echo 'votre-secret-aléatoire-64-caractères')"
+    
+    get_secret "KIMI_API_KEY" \
+        "Clé API pour Kimi (ou OpenAI si vous utilisez OpenAI)" \
+        "kimi-xxx ou sk-xxx"
+    
+    # Vérification
+    verify_secrets
+    
+    # Afficher les prochaines étapes
+    show_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
- Add interactive setup script (scripts/setup-secrets.sh)
- Add .env.example template for environment variables
- Update package.json with npm scripts for setup
- Rewrite README setup instructions with clear steps
- Document production deployment process
